### PR TITLE
fix: coverage CI

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: stable
 
       - name: Use Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: stable
+          version: nightly-99d3a4123eff947a0dbbfb7c3a27360db9e3a8c1
 
       - name: Use Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
NOTE:
- foundry-rs version `nightly-78c9ff4ef3569e45c9bd9824019cf4f4a1af0955` fails when compiling a file which path contains '.sol' in the folder name
- using `nightly-99d3a4123eff947a0dbbfb7c3a27360db9e3a8c1` instead